### PR TITLE
tw-29431765 | Create base image styles for all aspect ratios

### DIFF
--- a/config/core.entity_view_display.node.sa_page.default.yml
+++ b/config/core.entity_view_display.node.sa_page.default.yml
@@ -60,7 +60,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: sa_16_9
+      view_mode: wide_16_9
       link: false
     third_party_settings:
       nomarkup:

--- a/config/core.entity_view_display.node.sa_page.teaser.yml
+++ b/config/core.entity_view_display.node.sa_page.teaser.yml
@@ -81,7 +81,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: sa_16_9
+      view_mode: wide_16_9
       link: false
     third_party_settings:
       nomarkup:
@@ -89,6 +89,7 @@ content:
         separator: '|'
         referenced_entity: '1'
       ds:
+        ds_limit: ''
         ft:
           id: default
           settings:

--- a/config/core.entity_view_display.node.sa_post.default.yml
+++ b/config/core.entity_view_display.node.sa_post.default.yml
@@ -127,7 +127,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: sa_16_9
+      view_mode: wide_16_9
       link: false
     third_party_settings:
       nomarkup:

--- a/config/core.entity_view_display.node.sa_post.teaser.yml
+++ b/config/core.entity_view_display.node.sa_post.teaser.yml
@@ -41,6 +41,8 @@ third_party_settings:
             image_col_classes_token: ''
             content_col_classes: col-md-8
             content_col_classes_token: ''
+            height: 0
+            height_token: ''
     regions:
       image:
         - sa_featured_image
@@ -82,7 +84,7 @@ content:
     type: entity_reference_entity_view
     label: hidden
     settings:
-      view_mode: sa_16_9
+      view_mode: wide_16_9
       link: false
     third_party_settings:
       nomarkup:
@@ -90,6 +92,7 @@ content:
         separator: '|'
         referenced_entity: '1'
       ds:
+        ds_limit: ''
         ft:
           id: default
           settings:


### PR DESCRIPTION
## Description
Teamwork Ticket(s): [Create base image styles for all aspect ratios](https://kanopi.teamwork.com/app/tasks/29431765)

Update all image displays to use the new easy responsive image display modes. #31
https://github.com/kanopi/saplings-content-types/issues/12
https://github.com/kanopi/saplings-component-types/issues/31

So we use media image display modes in the two content types and a few components. We need to update those config files, make releases for all 3 repos and then test

## Acceptance Criteria
* Post and Page content types have been updated to display the new Easy Responsive Image views created. All view modes need to be updated.

## Deploy Notes
_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc. This should also include work that needs to be 
accomplished post-launch like enabling a plugin._
