### PR TITLE
Update canonical url for page content type metatags

### DIFF
--- a/config/metatag.metatag_defaults.node__sa_page.yml
+++ b/config/metatag.metatag_defaults.node__sa_page.yml
@@ -4,7 +4,7 @@ dependencies: {  }
 id: node__sa_page
 label: 'Content: Page'
 tags:
-  canonical_url: '[site:url]'
+  canonical_url: '[current-page:url:absolute]'
   description: '[node:sa_seo_description|node:sa_description]'
   image_src: '[node:sa_seo_image:entity:field_media_image:sa_social_media_facebook|node:sa_featured_image:entity:field_media_image:sa_social_media_facebook]'
   og_description: '[node:sa_seo_description|node:sa_description]'


### PR DESCRIPTION
## Description
Fixes the canonical_url for the page content type - setting it to the absolute URL of the current page, instead of the site url.