### PR TITLE
removes stats from available components on a page content type

### DIFF
--- a/config/field.field.node.sa_page.sa_components.yml
+++ b/config/field.field.node.sa_page.sa_components.yml
@@ -7,26 +7,30 @@ dependencies:
     - paragraphs.paragraphs_type.sa_accordion_item
     - paragraphs.paragraphs_type.sa_carousel_item
     - paragraphs.paragraphs_type.sa_faq_item
+    - paragraphs.paragraphs_type.sa_stat
     - paragraphs.paragraphs_type.sa_tab
   module:
     - entity_reference_revisions
+_core:
+  default_config_hash: XNMXpc3fPV7Nvi606htqRAxGD-2-Up37LYJiWNNuQcA
 id: node.sa_page.sa_components
 field_name: sa_components
 entity_type: node
 bundle: sa_page
 label: Components
-description: ""
+description: ''
 required: false
 translatable: false
-default_value: {}
-default_value_callback: ""
+default_value: {  }
+default_value_callback: ''
 settings:
-  handler: "default:paragraph"
+  handler: 'default:paragraph'
   handler_settings:
     target_bundles:
       sa_accordion_item: sa_accordion_item
       sa_carousel_item: sa_carousel_item
       sa_tab: sa_tab
+      sa_stat: sa_stat
       sa_faq_item: sa_faq_item
     negate: 1
     target_bundles_drag_drop:
@@ -48,6 +52,9 @@ settings:
       sa_carousel_item:
         weight: 18
         enabled: true
+      sa_columns:
+        weight: 23
+        enabled: false
       sa_faq:
         weight: 23
         enabled: false
@@ -63,6 +70,9 @@ settings:
       sa_side_by_side:
         weight: 21
         enabled: false
+      sa_stat:
+        weight: 29
+        enabled: true
       sa_tab:
         weight: 22
         enabled: true


### PR DESCRIPTION
## Description
An animated stats component is being added but should not be available on the page content type except within the columns paragraph
https://kanopi.teamwork.com/app/tasks/29486487

## Assumptions
* A list of things the code reviewer or project manager should know
* e.g. There is a known Javascript error in the console.log
* e.g. On any `multidev`, the popup plugin breaks.

## Steps to Validate
1. A list of steps to validate
1. Include direct links to test sites (specific nodes, admin screens, etc)
1. Be explicit

## Affected URL
[link_to_relevant_multidev_or_test_site](insert_link_here)

## Deploy Notes
_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc. This should also include work that needs to be 
accomplished post-launch like enabling a plugin._
