### PR TITLE
fixes missing entity browser module requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "drupal/access_unpublished": "*",
+        "drupal/entity_browser": "*",
         "drupal/field_group": "*",
         "drupal/inline_entity_form": "^3.0.0@rc",
         "drupal/metatag": "*",

--- a/config/core.entity_form_display.node.sa_page.default.yml
+++ b/config/core.entity_form_display.node.sa_page.default.yml
@@ -135,10 +135,10 @@ content:
       title: Component
       title_plural: Components
       edit_mode: closed
-      closed_mode: summary
+      closed_mode: preview
       autocollapse: none
       closed_mode_threshold: 0
-      add_mode: dropdown
+      add_mode: button
       form_display_mode: default
       default_paragraph_type: _none
       features:

--- a/recipe.yml
+++ b/recipe.yml
@@ -9,6 +9,7 @@ install:
   - menu_ui
   # Contrib.
   - access_unpublished
+  - entity_browser
   - field_group
   - inline_entity_form
   - metatag


### PR DESCRIPTION
## Description
Performing drush cim on a new Saplings install throws an error that entity browser will be removed but it is not currently installed by the recipe
